### PR TITLE
Plat 1170 readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Fitpay Corporation 
+Copyright (c) 2015-2016 Fitpay Corporation 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Fitpay Corporation 
+Copyright (c) 2015-2016 FitPay Inc. 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,41 @@
- # Fitpay iOS SDK
+# Fitpay iOS SDK - README.md
 
-[![Build Status](https://travis-ci.org/fitpay/fitpay-ios-sdk.svg?branch=develop)](https://travis-ci.org/fitpay/fitpay-ios-sdk)
 
-coming soon...
+## Building the app locally
+Ensure you have cocoapods installed, and the repo checked out:
+```shell
+sudo gem install cocoapods  
+cd ~  
+mkdir fitpay
+cd fitpay  
+git clone git@github.com:fitpay/fitpay-ios-sdk.git
+cd fitpay-ios-sdk
+pod install  
+```
+Open XCode, and add a project (->Open another project->/users/yourname/fipay/fitpay-ios-sdk)  
+
+Fit-Pay also utilizes a continuous integration system (travis) to build and test. Current Develop Branch Status: [![Build Status](https://travis-ci.org/fitpay/fitpay-ios-sdk.svg?branch=develop)](https://travis-ci.org/fitpay/fitpay-ios-sdk)
+
+
+## Running Tests Locally from XCode UI
+Open the project inside of XCode
+Filemenu -> View, Navigators, Show Test Navigators
+Right click on FitpaySDK tests, Enable tests
+Click on a test, and press "Play"
+
+## Running Tests From the Commandline
+```
+xcodebuild test -project FitpaySDK.xcodeproj -scheme FitpaySDK -destination 'platform=iOS Simulator,name=iPhone 6s'
+```
+
+
+## Contributing to the SDK
+We welcome contributions to the SDK. For your first few contributions please fork the repo, make your changes and submit a pull request. Internally we branch off of develop, test, and PR-review the branch before merging to develop (moderately stable). Releases to Master happen less frequently, undergo more testing, and can be considered stable. For more information, please read:  [http://nvie.com/posts/a-successful-git-branching-model/](http://nvie.com/posts/a-successful-git-branching-model/)
+
+## License
+This code is licensed under the MIT license. More information can be found in the [LICENSE](LICENSE) file contained in this repository.
+
+## Questions? Comments? Concerns?
+Please contact the team via a github issue, OR, feel free to email us: sdk@fit-pay.com
+
+


### PR DESCRIPTION
This does 3 things: Updates the license file, updates README.md, and changes our default build to demo instead of dev (both for CI and end users)