### PR TITLE
Capture restClient reference. We should have strong reference of rest…

### DIFF
--- a/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
+++ b/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
@@ -44,6 +44,13 @@ open class SyncRequest {
         self.user = user
         self.deviceInfo = deviceInfo
         self.paymentDevice = paymentDevice
+        
+        // capture restClient reference
+        if user?.client != nil {
+            self.restClient = user?.client
+        } else if deviceInfo?.client != nil {
+            self.restClient = deviceInfo?.client
+        }
     }
     
     public let requestTime: Date
@@ -58,6 +65,9 @@ open class SyncRequest {
     
     private var state = SyncRequestState.pending
     
+    // we should capture restClient to prevent deallocation
+    private var restClient: RestClient?
+
     internal func update(state: SyncRequestState) {
         if state == .inProgress {
             self.syncStartTime = Date()


### PR DESCRIPTION
…Client while it’s in sync queue or sync in progress process.

I tried to implement this option: "We can make strong reference only in that places where and when restClient is needed".
In my tests, it works, but it would be great to test it with customers flow.