### PR TITLE
Function to access CreditCard.isDefault from Objective-C

### DIFF
--- a/FitpaySDK/Rest/Models/CreditCard.swift
+++ b/FitpaySDK/Rest/Models/CreditCard.swift
@@ -166,6 +166,14 @@ open class CreditCard: NSObject, ClientModel, Mappable, SecretApplyable
         }
     }
 
+    @objc open func getIsDefault() -> Bool {
+        if let _isDefault = isDefault {
+            return _isDefault
+        }
+        
+        return false
+    }
+    
     /**
      Delete a single credit card from a user's profile. If you delete a card that is currently the default source, then the most recently added source will become the new default.
      


### PR DESCRIPTION
Optional Bools are not accessible from Objective-C.  Added a function to allow Objective-C code to check whether a given CreditCard is a wallet's default card.  If a CreditCard does not have a value for `isDefault`, assume that it is not the default card.