### PR TITLE
PLAT-4325 iOS - Retrieve and send locale from phone

### DIFF
--- a/FitpaySDK/PaymentDevice/IdVerificationResponse.swift
+++ b/FitpaySDK/PaymentDevice/IdVerificationResponse.swift
@@ -75,8 +75,15 @@ open class IdVerificationResponse: NSObject, Mappable {
     open var billingState: String?
     open var billingZip: String?
     
+    private var locale: String? //[language designator ISO-639-1]‌‌‌‌-[region designator ISO 3166-1 alpha-2]
+    
     public override init() {
         super.init()
+        if let languageCode = NSLocale.current.languageCode, let regionCode = NSLocale.current.regionCode {
+            self.locale = languageCode + "-" + regionCode
+        } else {
+            self.locale = "en-US"
+        }
     }
     
     public required init?(map: Map) {
@@ -108,5 +115,6 @@ open class IdVerificationResponse: NSObject, Mappable {
         billingCity <- map["billingCity"]
         billingState <- map["billingState"]
         billingZip <- map["billingZip"]
+        locale <- map["locale"]
     }
 }

--- a/FitpaySDK/PaymentDevice/PaymentDevice.swift
+++ b/FitpaySDK/PaymentDevice/PaymentDevice.swift
@@ -257,7 +257,12 @@
     ///
     /// - Parameter completion: when completion will be called, then the response will be sent to RTM
     public func handleIdVerificationRequest(completion: @escaping (IdVerificationResponse)->Void) {
-        self.deviceInterface.handleIdVerificationRequest?(completion: completion)
+        if let handleIdVerificationRequest = self.deviceInterface.handleIdVerificationRequest {
+            handleIdVerificationRequest(completion)
+        } else {
+            let onlyLocationResponse = IdVerificationResponse()
+            completion(onlyLocationResponse)
+        }
     }
     
     override public init() {


### PR DESCRIPTION
Under iOS 11, [NSLocale currentLocale] only returns languages supported by your app’s localizations. If your app only supports English (as the base localization), then no matter what language the user selects on the device, currentLocale will always return English.