### PR TITLE
Transaction value was getting nil due to deprecated type

### DIFF
--- a/FitpaySDK.xcodeproj/project.pbxproj
+++ b/FitpaySDK.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		371CB3041F45DA4F0019A766 /* RtmMessageHandlerV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371CB3021F45DA4F0019A766 /* RtmMessageHandlerV4.swift */; };
 		37327B9A1E9BAB5A003B8918 /* SwCrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37327B991E9BAB5A003B8918 /* SwCrypt.swift */; };
 		37327B9B1E9CC2EF003B8918 /* SwCrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37327B991E9BAB5A003B8918 /* SwCrypt.swift */; };
+		37330EB620289E2000948BC6 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37330EB420289DCF00948BC6 /* ModelsTests.swift */; };
+		37330EB720289E2100948BC6 /* ModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37330EB420289DCF00948BC6 /* ModelsTests.swift */; };
 		373E0C261F682715000B23C2 /* FitpaySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AD9229D1C1F7EFC007693AB /* FitpaySDK.framework */; };
 		373E0C2C1F682730000B23C2 /* testHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7EE11A1CFE0A2B00503BC8 /* testHelpers.swift */; };
 		373E0C2F1F682753000B23C2 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373E0C2D1F682753000B23C2 /* AuthenticationTests.swift */; };
@@ -203,7 +205,7 @@
 		43FBB25BF1B9D938C2A0E066 /* Pods_FitpaySDKAuthenticationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EC01D3DCF5D3DB9EB585C01 /* Pods_FitpaySDKAuthenticationTests.framework */; };
 		68E27BF45BD5866DCC3F3C61 /* Pods_FitpaySDKTestsPods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8D031FFA4B05A5DCB130BE6 /* Pods_FitpaySDKTestsPods.framework */; };
 		81A3D7AA8E4C39236434E760 /* Pods_FitpaySDKDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5293BFF5D315767C7D895F /* Pods_FitpaySDKDemo.framework */; };
-		8400F8A51CA036AE003F15B2 /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8400F8A51CA036AE003F15B2 /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8400F8AC1CA130C4003F15B2 /* NSData+CRC32.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400F8AB1CA130C4003F15B2 /* NSData+CRC32.swift */; };
 		8425931B1CAA605B0006FFA6 /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8425931A1CAA605B0006FFA6 /* SyncManager.swift */; };
 		8425931D1CAA613E0006FFA6 /* SyncStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8425931C1CAA613E0006FFA6 /* SyncStorage.swift */; };
@@ -381,7 +383,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8400F8A51CA036AE003F15B2 /* BuildFile in Embed Frameworks */,
+				8400F8A51CA036AE003F15B2 /* (null) in Embed Frameworks */,
 				8482FE891CA0338900966742 /* FitpaySDK.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -418,6 +420,7 @@
 		371CB2FF1F444ACF0019A766 /* NonAPDUConfirmOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NonAPDUConfirmOperation.swift; sourceTree = "<group>"; };
 		371CB3021F45DA4F0019A766 /* RtmMessageHandlerV4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RtmMessageHandlerV4.swift; sourceTree = "<group>"; };
 		37327B991E9BAB5A003B8918 /* SwCrypt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwCrypt.swift; sourceTree = "<group>"; };
+		37330EB420289DCF00948BC6 /* ModelsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelsTests.swift; sourceTree = "<group>"; };
 		373E0C211F682715000B23C2 /* FitpaySDKAuthenticationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitpaySDKAuthenticationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		373E0C251F682715000B23C2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		373E0C2D1F682753000B23C2 /* AuthenticationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
@@ -763,6 +766,7 @@
 		0AD922AB1C1F7EFC007693AB /* FitpaySDKTests */ = {
 			isa = PBXGroup;
 			children = (
+				37330EB420289DCF00948BC6 /* ModelsTests.swift */,
 				9AB68E431C84A25B00A0E172 /* JWETests.swift */,
 				9AA50BDE1C7E096D000FA546 /* RestClientTests.swift */,
 				9AA5BDAA1C7B54B600EDF2F6 /* RestSessionTests.swift */,
@@ -2080,6 +2084,7 @@
 				9AD200771CE235530009CDA6 /* RestAPIConstants.swift in Sources */,
 				9B65A33D1CDD2D78007A7D7D /* MockPaymentDeviceTests.swift in Sources */,
 				9AB68E441C84A25B00A0E172 /* JWETests.swift in Sources */,
+				37330EB620289E2000948BC6 /* ModelsTests.swift in Sources */,
 				37C94AAE1FE15E96009C0FE7 /* SyncManagerTests.swift in Sources */,
 				9AA50BDF1C7E096D000FA546 /* RestClientTests.swift in Sources */,
 				0A7EE11B1CFE0A2B00503BC8 /* testHelpers.swift in Sources */,
@@ -2108,6 +2113,7 @@
 				3A46E14B1DF023F9002D0270 /* RestAPIConstants.swift in Sources */,
 				3A46E14C1DF023F9002D0270 /* MockPaymentDeviceTests.swift in Sources */,
 				3A46E14D1DF023F9002D0270 /* JWETests.swift in Sources */,
+				37330EB720289E2100948BC6 /* ModelsTests.swift in Sources */,
 				37C94AAF1FE15E96009C0FE7 /* SyncManagerTests.swift in Sources */,
 				3A46E14E1DF023F9002D0270 /* RestClientTests.swift in Sources */,
 				3A46E14F1DF023F9002D0270 /* testHelpers.swift in Sources */,

--- a/FitpaySDK/Rest/Models/Transaction.swift
+++ b/FitpaySDK/Rest/Models/Transaction.swift
@@ -6,7 +6,7 @@ open class Transaction : NSObject, ClientModel, Mappable
     internal var links:[ResourceLink]?
     open var transactionId:String?
     open var transactionType:String?
-    open var amount:Double? //Foundation.NSDecimalNumber is deprecated in ObjectMapper. Other option is to use NSDecimalNumberTransform
+    open var amount:NSDecimalNumber?
     open var currencyCode:String?
     open var authorizationStatus:String?
     open var transactionTime:String?
@@ -28,7 +28,7 @@ open class Transaction : NSObject, ClientModel, Mappable
         links <- (map["_links"], ResourceLinkTransformType())
         transactionId <- map["transactionId"]
         transactionType <- map["transactionType"]
-        amount <- map["amount"] 
+        amount <- (map["amount"], DecimalNumberTransform())
         currencyCode <- map["currencyCode"]
         authorizationStatus <- map["authorizationStatus"]
         transactionTime <- map["transactionTime"]

--- a/FitpaySDK/Rest/Models/Transaction.swift
+++ b/FitpaySDK/Rest/Models/Transaction.swift
@@ -6,7 +6,7 @@ open class Transaction : NSObject, ClientModel, Mappable
     internal var links:[ResourceLink]?
     open var transactionId:String?
     open var transactionType:String?
-    open var amount:Foundation.NSDecimalNumber? //TODO: consider keeping it as String
+    open var amount:Double? //Foundation.NSDecimalNumber is deprecated in ObjectMapper. Other option is to use NSDecimalNumberTransform
     open var currencyCode:String?
     open var authorizationStatus:String?
     open var transactionTime:String?
@@ -28,7 +28,7 @@ open class Transaction : NSObject, ClientModel, Mappable
         links <- (map["_links"], ResourceLinkTransformType())
         transactionId <- map["transactionId"]
         transactionType <- map["transactionType"]
-        amount <- map["amount"]
+        amount <- map["amount"] 
         currencyCode <- map["currencyCode"]
         authorizationStatus <- map["authorizationStatus"]
         transactionTime <- map["transactionTime"]

--- a/FitpaySDK/Rest/Models/Transforms.swift
+++ b/FitpaySDK/Rest/Models/Transforms.swift
@@ -36,3 +36,27 @@ internal class NSTimeIntervalTransform: TransformType
         return nil
     }
 }
+
+internal class DecimalNumberTransform: TransformType {
+    public typealias Object = NSDecimalNumber
+    public typealias JSON = String
+    
+    public init() {}
+    
+    public func transformFromJSON(_ value: Any?) -> NSDecimalNumber? {
+        if let string = value as? String {
+            return NSDecimalNumber(string: string)
+        } else if let number = value as? NSNumber {
+            let handler = NSDecimalNumberHandler(roundingMode: .plain, scale: 3, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
+            return NSDecimalNumber(decimal: number.decimalValue).rounding(accordingToBehavior: handler)
+        } else if let double = value as? Double {
+            return NSDecimalNumber(floatLiteral: double)
+        }
+        return nil
+    }
+    
+    public func transformToJSON(_ value: NSDecimalNumber?) -> String? {
+        guard let value = value else { return nil }
+        return value.description
+    }
+}

--- a/FitpaySDKTests/ModelsTests.swift
+++ b/FitpaySDKTests/ModelsTests.swift
@@ -1,0 +1,30 @@
+
+//
+//  ModelsTests.swift
+//  FitpaySDK
+//
+//  Created by Anton Popovichenko on 05.02.2018.
+//  Copyright © 2018 Fitpay. All rights reserved.
+//
+
+import XCTest
+import ObjectMapper
+@testable import FitpaySDK
+
+class TransactionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testParsingDecimalValue() {
+        let json = "{\"amount\": 0.691}"
+        let transaction = Transaction(JSONString: json)
+        
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.amount?.description ?? "", "0.691")
+    }
+}


### PR DESCRIPTION
Root cause was a deprecated type. The simplest resolution is to use Double as suggested by the customer who found the bug. There is a custom transform method to make Foundation.NSDecimalNumber workable but since we can't store the data anyways, I don't think there are any negative consequences to using a Double.