### PR TITLE
Test CreateCreditCardsWithDeviceId

### DIFF
--- a/FitpaySDK/PaymentDevice/PaymentDevice.swift
+++ b/FitpaySDK/PaymentDevice/PaymentDevice.swift
@@ -234,11 +234,11 @@
     
     func processNonAPDUCommit(commit: Commit, completion: @escaping (_ state: NonAPDUCommitState?, _ error: NSError?) -> Void) {
         if let processNonAPDUCommit = self.deviceInterface.processNonAPDUCommit {
-            self.deviceDisconnectedBinding = self.bindToEvent(eventType: PaymentDeviceEventTypes.onDeviceDisconnected, completion: { (event) in
+            self.deviceDisconnectedBinding = self.bindToEvent(eventType: PaymentDeviceEventTypes.onDeviceDisconnected) { (event) in
                 log.error("APDU_DATA: Device is disconnected during process non-APDU commit.")
                 self.removeDisconnectedBinding()
                 completion(.failed, NSError.error(code: PaymentDevice.ErrorCode.nonApduProcessingTimeout, domain: PaymentDevice.self))
-            })
+            }
             
             var isCompleteProcessing = false
             DispatchQueue.global().asyncAfter(deadline: .now() + self.commitProcessingTimeout) {

--- a/FitpaySDK/PaymentDevice/SyncQueue/SyncRequestsQueue.swift
+++ b/FitpaySDK/PaymentDevice/SyncQueue/SyncRequestsQueue.swift
@@ -40,6 +40,7 @@ open class SyncRequestQueue {
         
         if !request.isEmptyRequest {
             lastFullSyncRequest = request
+            lastFullSyncRequest?.deviceInfo?.updateNotificationTokenIfNeeded()
         }
         
         queue.add(request: request)

--- a/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
@@ -22,6 +22,12 @@ import Foundation
     open var topOfWalletAPDUCommands: [APDUCommand]?
     open var tokenLastFour: String?
     
+    /// The credit card expiration month - placed directly on card in creditCardCreated Events (otherwise in CardInfo)
+    open var expMonth: Int?
+    
+    /// The credit card expiration year in 4 digits - placed directly on card in creditCardCreated Events (otherwise in CardInfo)
+    open var expYear: Int?
+    
     var links: [ResourceLink]?
     var encryptedData: String?
 
@@ -106,6 +112,8 @@ import Foundation
         case externalTokenReference
         case topOfWalletAPDUCommands = "offlineSeActions.topOfWallet.apduCommands"
         case tokenLastFour
+        case expMonth
+        case expYear
     }
 
     public required init(from decoder: Decoder) throws {
@@ -131,6 +139,8 @@ import Foundation
         externalTokenReference = try? container.decode(.externalTokenReference)
         topOfWalletAPDUCommands = try? container.decode(.topOfWalletAPDUCommands)
         tokenLastFour = try? container.decode(.tokenLastFour)
+        expMonth = try? container.decode(.expMonth)
+        expYear = try? container.decode(.expYear)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -156,6 +166,8 @@ import Foundation
         try? container.encode(externalTokenReference, forKey: .externalTokenReference)
         try? container.encode(topOfWalletAPDUCommands, forKey: .topOfWalletAPDUCommands)
         try? container.encode(tokenLastFour, forKey: .tokenLastFour)
+        try? container.encode(expMonth, forKey: .expMonth)
+        try? container.encode(expYear, forKey: .expYear)
     }
     
     func applySecret(_ secret: Foundation.Data, expectedKeyId: String?) {

--- a/FitpaySDKTests/Rest/Models/UsersTests.swift
+++ b/FitpaySDKTests/Rest/Models/UsersTests.swift
@@ -1,5 +1,8 @@
 import XCTest
+
 @testable import FitpaySDK
+
+import Alamofire
 
 class UsersTests: BaseTestProvider {
     
@@ -64,7 +67,10 @@ class UsersTests: BaseTestProvider {
         let expectation = self.expectation(description: "getCreditCards")
 
         user?.getCreditCards(excludeState: [], limit: 10, offset: 0, deviceId: "1234") { (creditCardCollection, error) in
-            XCTAssertEqual(self.mockRestRequest.lastCalledParams?["deviceId"] as? String, "1234")
+            XCTAssertEqual(self.mockRestRequest.lastParams?["deviceId"] as? String, "1234")
+            let lastEncodingAsURL = self.mockRestRequest.lastEncoding as? URLEncoding
+            XCTAssertNotNil(lastEncodingAsURL)
+            
             expectation.fulfill()
         }
         
@@ -78,7 +84,10 @@ class UsersTests: BaseTestProvider {
         let creditCardInfo = CardInfo(pan: "123456", expMonth: 12, expYear: 2020, cvv: "123", name: "Jeremiah Harris", address: address, riskData: nil)
         
         user.createCreditCard(cardInfo: creditCardInfo, deviceId: "1234") { (creditCard, error) in
-            XCTAssertEqual(self.mockRestRequest.lastCalledParams?["deviceId"] as? String, "1234")
+            XCTAssertEqual(self.mockRestRequest.lastParams?["deviceId"] as? String, "1234")
+            let lastEncodingAsJson = self.mockRestRequest.lastEncoding as? JSONEncoding
+            XCTAssertNotNil(lastEncodingAsJson)
+            
             expectation.fulfill()
         }
         

--- a/FitpaySDKTests/Rest/Models/UsersTests.swift
+++ b/FitpaySDKTests/Rest/Models/UsersTests.swift
@@ -78,7 +78,7 @@ class UsersTests: BaseTestProvider {
     }
     
     func testCreateCreditCardsWithDeviceId() {
-        let expectation = self.expectation(description: "getCreditCards")
+        let expectation = self.expectation(description: "createCreditCard")
         
         let address = Address(street1: "123 Lane", street2: nil, street3: nil, city: "Boulder", state: "Colorado", postalCode: "80401", countryCode: nil)
         let creditCardInfo = CardInfo(pan: "123456", expMonth: 12, expYear: 2020, cvv: "123", name: "Jeremiah Harris", address: address, riskData: nil)

--- a/FitpaySDKTests/Rest/Models/UsersTests.swift
+++ b/FitpaySDKTests/Rest/Models/UsersTests.swift
@@ -60,10 +60,24 @@ class UsersTests: BaseTestProvider {
         XCTAssertEqual(json?["encryptedData"] as? String, "some data")
     }
     
-    func testGetCreditCards() {
+    func testGetCreditCardsWithDeviceId() {
         let expectation = self.expectation(description: "getCreditCards")
 
         user?.getCreditCards(excludeState: [], limit: 10, offset: 0, deviceId: "1234") { (creditCardCollection, error) in
+            XCTAssertEqual(self.mockRestRequest.lastCalledParams?["deviceId"] as? String, "1234")
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+    
+    func testCreateCreditCardsWithDeviceId() {
+        let expectation = self.expectation(description: "getCreditCards")
+        
+        let address = Address(street1: "123 Lane", street2: nil, street3: nil, city: "Boulder", state: "Colorado", postalCode: "80401", countryCode: nil)
+        let creditCardInfo = CardInfo(pan: "123456", expMonth: 12, expYear: 2020, cvv: "123", name: "Jeremiah Harris", address: address, riskData: nil)
+        
+        user.createCreditCard(cardInfo: creditCardInfo, deviceId: "1234") { (creditCard, error) in
             XCTAssertEqual(self.mockRestRequest.lastCalledParams?["deviceId"] as? String, "1234")
             expectation.fulfill()
         }

--- a/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
+++ b/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
@@ -6,7 +6,8 @@ import Alamofire
 
 class MockRestRequest: RestRequestable {
     
-    var lastCalledParams: [String: Any]?
+    var lastParams: [String: Any]?
+    var lastEncoding: ParameterEncoding?
     
     func makeRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RestRequestable.RequestHandler) {
         guard let urlString = try? url.asURL().absoluteString else {
@@ -14,7 +15,8 @@ class MockRestRequest: RestRequestable {
             return
         }
         
-        lastCalledParams =  parameters
+        lastParams = parameters
+        lastEncoding = encoding
         
         var data: Any? = nil
         


### PR DESCRIPTION
- adding needed expMonth and expYear for pagare
- adding an updateNotification token to be more seamless