### PR TITLE
Asset Fix - send back data instead of checking for json

### DIFF
--- a/FitpaySDK/Rest/RestClient.swift
+++ b/FitpaySDK/Rest/RestClient.swift
@@ -445,8 +445,7 @@ extension RestClient {
     public typealias AssetsHandler = (_ asset: Asset?, _ error: ErrorResponse?) -> Void
     
     func assets(_ url: String, completion: @escaping AssetsHandler) {
-        
-        self.restRequest.makeRequest(url: url, method: .get, parameters: nil, encoding: URLEncoding.default, headers: nil) { (resultValue, error) in
+        self.restRequest.makeDataRequest(url: url, method: .get, parameters: nil, encoding: URLEncoding.default, headers: nil) { (resultValue, error) in
             guard let resultValue = resultValue as? Data else {
                 completion(nil, error)
                 return

--- a/FitpaySDK/Rest/RestClient.swift
+++ b/FitpaySDK/Rest/RestClient.swift
@@ -445,7 +445,7 @@ extension RestClient {
     public typealias AssetsHandler = (_ asset: Asset?, _ error: ErrorResponse?) -> Void
     
     func assets(_ url: String, completion: @escaping AssetsHandler) {
-        self.restRequest.makeDataRequest(url: url, method: .get, parameters: nil, encoding: URLEncoding.default, headers: nil) { (resultValue, error) in
+        self.restRequest.makeDataRequest(url: url) { (resultValue, error) in
             guard let resultValue = resultValue as? Data else {
                 completion(nil, error)
                 return

--- a/FitpaySDK/Rest/RestRequest.swift
+++ b/FitpaySDK/Rest/RestRequest.swift
@@ -5,7 +5,7 @@ public protocol RestRequestable {
     typealias RequestHandler = (_ resultValue: Any?, _ error: ErrorResponse?) -> Void
 
     func makeRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RequestHandler)
-    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RequestHandler)
+    func makeDataRequest(url: URLConvertible, completion: @escaping RequestHandler)
 }
 
 class RestRequest: RestRequestable {
@@ -38,10 +38,10 @@ class RestRequest: RestRequestable {
         }
     }
     
-    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters? = nil, encoding: ParameterEncoding = JSONEncoding.default, headers: HTTPHeaders? = nil, completion: @escaping RequestHandler) {
-        log.verbose("API_REQUEST: url=\(url), method=\(method)")
+    func makeDataRequest(url: URLConvertible, completion: @escaping RequestHandler) {
+        log.verbose("API_REQUEST: request data url=\(url)")
         
-        let request = self.manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
+        let request = self.manager.request(url, method: .get, parameters: nil, encoding: URLEncoding.default, headers: nil)
         request.validate(statusCode: 200..<300).response { (response) in
             if let resultValue = response.data {
                 completion(resultValue, nil)

--- a/FitpaySDK/Rest/RestRequest.swift
+++ b/FitpaySDK/Rest/RestRequest.swift
@@ -5,6 +5,7 @@ public protocol RestRequestable {
     typealias RequestHandler = (_ resultValue: Any?, _ error: ErrorResponse?) -> Void
 
     func makeRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RequestHandler)
+    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RequestHandler)
 }
 
 class RestRequest: RestRequestable {
@@ -29,6 +30,28 @@ class RestRequest: RestRequestable {
             } else if response.result.error != nil {
                 let JSON = response.data!.UTF8String
                 let error = (try? ErrorResponse(JSON)) ?? ErrorResponse(domain: RestClient.self, errorCode: response.response?.statusCode ?? 0 , errorMessage: response.result.error?.localizedDescription)
+                completion(nil, error)
+                
+            } else {
+                completion(nil, ErrorResponse.unhandledError(domain: RestClient.self))
+            }
+        }
+    }
+    
+    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters? = nil, encoding: ParameterEncoding = JSONEncoding.default, headers: HTTPHeaders? = nil, completion: @escaping RequestHandler) {
+        log.verbose("API_REQUEST: url=\(url), method=\(method)")
+        
+        let request = self.manager.request(url, method: method, parameters: parameters, encoding: encoding, headers: headers)
+        request.validate(statusCode: 200..<300).response { (response) in
+            if let resultValue = response.data {
+                completion(resultValue, nil)
+                
+            } else if response.response?.statusCode == 202 {
+                completion(nil, nil)
+                
+            } else if response.error != nil {
+                let JSON = response.data!.UTF8String
+                let error = (try? ErrorResponse(JSON)) ?? ErrorResponse(domain: RestClient.self, errorCode: response.response?.statusCode ?? 0 , errorMessage: response.error?.localizedDescription)
                 completion(nil, error)
                 
             } else {

--- a/FitpaySDKTests/Rest/Models/UsersTests.swift
+++ b/FitpaySDKTests/Rest/Models/UsersTests.swift
@@ -9,11 +9,12 @@ class UsersTests: BaseTestProvider {
     var user: User!
     var restClient: RestClient!
     var testHelper: TestHelper!
-    var mockRestRequest = MockRestRequest()
-
+    
+    let restRequest = MockRestRequest()
+    
     override func setUp() {
-        let session = RestSession(restRequest: mockRestRequest)
-        restClient = RestClient(session: session, restRequest: mockRestRequest)
+        let session = RestSession(restRequest: restRequest)
+        restClient = RestClient(session: session, restRequest: restRequest)
         testHelper = TestHelper(session: session, client: restClient)
         
         FitpayConfig.clientId = "fp_webapp_pJkVp2Rl"
@@ -65,10 +66,10 @@ class UsersTests: BaseTestProvider {
     
     func testGetCreditCardsWithDeviceId() {
         let expectation = self.expectation(description: "getCreditCards")
-
+        
         user?.getCreditCards(excludeState: [], limit: 10, offset: 0, deviceId: "1234") { (creditCardCollection, error) in
-            XCTAssertEqual(self.mockRestRequest.lastParams?["deviceId"] as? String, "1234")
-            let lastEncodingAsURL = self.mockRestRequest.lastEncoding as? URLEncoding
+            XCTAssertEqual(self.restRequest.lastParams?["deviceId"] as? String, "1234")
+            let lastEncodingAsURL = self.restRequest.lastEncoding as? URLEncoding
             XCTAssertNotNil(lastEncodingAsURL)
             
             expectation.fulfill()
@@ -84,8 +85,8 @@ class UsersTests: BaseTestProvider {
         let creditCardInfo = CardInfo(pan: "123456", expMonth: 12, expYear: 2020, cvv: "123", name: "Jeremiah Harris", address: address, riskData: nil)
         
         user.createCreditCard(cardInfo: creditCardInfo, deviceId: "1234") { (creditCard, error) in
-            XCTAssertEqual(self.mockRestRequest.lastParams?["deviceId"] as? String, "1234")
-            let lastEncodingAsJson = self.mockRestRequest.lastEncoding as? JSONEncoding
+            XCTAssertEqual(self.restRequest.lastParams?["deviceId"] as? String, "1234")
+            let lastEncodingAsJson = self.restRequest.lastEncoding as? JSONEncoding
             XCTAssertNotNil(lastEncodingAsJson)
             
             expectation.fulfill()

--- a/FitpaySDKTests/Rest/RestClientTests.swift
+++ b/FitpaySDKTests/Rest/RestClientTests.swift
@@ -8,6 +8,8 @@ class RestClientTests: XCTestCase {
     var client: RestClient!
     var testHelper: TestHelper!
     
+    let restRequest = MockRestRequest()
+    
     override func invokeTest() {
         // stop test on first failure - kind of like jUnit.  Avoid unexpected null references etc
         self.continueAfterFailure = false
@@ -24,8 +26,8 @@ class RestClientTests: XCTestCase {
         FitpayConfig.clientId = "fp_webapp_pJkVp2Rl"
         FitpayConfig.apiURL = "https://api.fit-pay.com"
         FitpayConfig.authURL = "https://auth.fit-pay.com"
-        session = RestSession(restRequest: MockRestRequest())
-        client = RestClient(session: session!, restRequest: MockRestRequest())
+        session = RestSession(restRequest: restRequest)
+        client = RestClient(session: session!, restRequest: restRequest)
         testHelper = TestHelper(session: session, client: client)
     }
     

--- a/FitpaySDKTests/Rest/RestSessionTests.swift
+++ b/FitpaySDKTests/Rest/RestSessionTests.swift
@@ -9,11 +9,13 @@ class RestSessionTests: XCTestCase {
     var clientId = "fp_webapp_pJkVp2Rl"
     let password = "1029"
     
+    let restRequest = MockRestRequest()
+    
     override func setUp() {
         super.setUp()
 
-        session = RestSession(restRequest: MockRestRequest())
-        self.client =  RestClient(session: self.session!, restRequest: MockRestRequest())
+        session = RestSession(restRequest: restRequest)
+        self.client =  RestClient(session: self.session!, restRequest: restRequest)
         self.testHelper = TestHelper(session: self.session, client: self.client)
         
         FitpayConfig.clientId = clientId

--- a/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
+++ b/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
@@ -87,14 +87,14 @@ class MockRestRequest: RestRequestable {
         
     }
     
-    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RestRequestable.RequestHandler) {
+    func makeDataRequest(url: URLConvertible, completion: @escaping RestRequestable.RequestHandler) {
         guard let urlString = try? url.asURL().absoluteString else {
             completion(nil, ErrorResponse.unhandledError(domain: RestClient.self))
             return
         }
         
-        lastParams = parameters
-        lastEncoding = encoding
+        lastParams = nil
+        lastEncoding = URLEncoding.default
         
         if urlString.contains("assets") {
             let imagePath =  Bundle(for: type(of: self)).path(forResource: "mocImage", ofType: "png")!

--- a/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
+++ b/FitpaySDKTests/TestSpecific/Mocks/MockRestRequest.swift
@@ -5,7 +5,7 @@ import Alamofire
 @testable import FitpaySDK
 
 class MockRestRequest: RestRequestable {
-    
+
     var lastParams: [String: Any]?
     var lastEncoding: ParameterEncoding?
     
@@ -77,10 +77,6 @@ class MockRestRequest: RestRequestable {
         } else if urlString.contains("resetDeviceTasks") {
             data = loadDataFromJSONFile(filename: "resetDeviceTask")
             
-        } else if urlString.contains("assets") {
-            let imagePath =  Bundle(for: type(of: self)).path(forResource: "mocImage", ofType: "png")!
-            data = UIImagePNGRepresentation(UIImage(contentsOfFile: imagePath)!)
-
         }
         
         if let data = data {
@@ -89,6 +85,24 @@ class MockRestRequest: RestRequestable {
             completion(nil, ErrorResponse.unhandledError(domain: RestClient.self))
         }
         
+    }
+    
+    func makeDataRequest(url: URLConvertible, method: HTTPMethod, parameters: Parameters?, encoding: ParameterEncoding, headers: HTTPHeaders?, completion: @escaping RestRequestable.RequestHandler) {
+        guard let urlString = try? url.asURL().absoluteString else {
+            completion(nil, ErrorResponse.unhandledError(domain: RestClient.self))
+            return
+        }
+        
+        lastParams = parameters
+        lastEncoding = encoding
+        
+        if urlString.contains("assets") {
+            let imagePath =  Bundle(for: type(of: self)).path(forResource: "mocImage", ofType: "png")!
+            let data = UIImagePNGRepresentation(UIImage(contentsOfFile: imagePath)!)
+            if let data = data {
+                completion(data, nil)
+            }
+        }
     }
     
     private func loadDataFromJSONFile(filename: String) -> String? {

--- a/FitpaySDKTests/TestSpecific/TestHelper.swift
+++ b/FitpaySDKTests/TestSpecific/TestHelper.swift
@@ -324,8 +324,8 @@ class TestHelper {
         return randomString as String
     }
     
-    class func getEmail() -> String {
-        return "ms7RsgsX@X5pvb.koWBX"
+    class func getEmail(random: Bool = false) -> String {
+        return random ? "testUser\(Int(Date().timeIntervalSince1970 * 1000))@test.com" : "ms7RsgsX@X5pvb.koWBX"
     }
     
     func randomPan() -> String {
@@ -333,7 +333,16 @@ class TestHelper {
     }
     
     func generateRandomSeId() -> String {
-        let secureElementId = MockPaymentDeviceConnector(paymentDevice: PaymentDevice()).deviceInfo()!.secureElement?.secureElementId ?? ""
-        return secureElementId
+        if let deviceSecureElementId = MockPaymentDeviceConnector(paymentDevice: PaymentDevice()).deviceInfo()!.secureElement?.secureElementId {
+            return deviceSecureElementId
+        } else {
+            var dateString = String(format: "%2X", UInt64(Date().timeIntervalSince1970))
+            while dateString.count < 12 {
+                dateString = "0" + dateString
+            }
+            let secureElementId = "DEADBEEF0000" + "528704504258" +  dateString + "FFFF427208236250082462502041FFFF082562502041FFFF"
+            return secureElementId
+        }
+        
     }
 }


### PR DESCRIPTION
improve testing to make it easier to go back and forth between mock and real requests