### PR TITLE
Fix Xcode 9.2 compile error

### DIFF
--- a/FitpaySDK/PaymentDevice/Interfaces/MockPaymentDeviceConnector.swift
+++ b/FitpaySDK/PaymentDevice/Interfaces/MockPaymentDeviceConnector.swift
@@ -49,7 +49,7 @@ public class MockPaymentDeviceConnector: NSObject {
     private func sendAPDUData(apduCommand: APDUCommand, sequenceNumber: UInt16) {
         var response = ""
         
-        switch apduCommand.type {
+        switch apduCommand.type ?? "" {
         case apduCommandTypes.GET_CPLC.rawValue:
             response = "9F7F2A" + generateRandomSeId() + "9000"
         case apduCommandTypes.GET_CASD_P1.rawValue:


### PR DESCRIPTION
Fix for Xcode 9.2 compilation error.
Add default non-optional value to switch statement because apduCommand.type is optional value