### PR TITLE
Adding provisioningFailedReason to Credit Card Model

### DIFF
--- a/FitpaySDK.xcodeproj/project.pbxproj
+++ b/FitpaySDK.xcodeproj/project.pbxproj
@@ -166,6 +166,8 @@
 		27C34A4420CEC635005EE649 /* CardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C34A4220CEC635005EE649 /* CardInfo.swift */; };
 		27C34A4620CECBA8005EE649 /* TermsAssetReferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C34A4520CECBA8005EE649 /* TermsAssetReferences.swift */; };
 		27C34A4720CECBA8005EE649 /* TermsAssetReferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C34A4520CECBA8005EE649 /* TermsAssetReferences.swift */; };
+		27C76B0321A30D260067E7CF /* ProvisioningFailedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C76B0221A30D260067E7CF /* ProvisioningFailedReason.swift */; };
+		27C76B0421A30D260067E7CF /* ProvisioningFailedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C76B0221A30D260067E7CF /* ProvisioningFailedReason.swift */; };
 		27CFE11E21236FF500AE116B /* JWTError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CFE11D21236FF500AE116B /* JWTError.swift */; };
 		27CFE11F21236FF500AE116B /* JWTError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CFE11D21236FF500AE116B /* JWTError.swift */; };
 		27CFE121212371D900AE116B /* JWS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CFE120212371D900AE116B /* JWS.swift */; };
@@ -639,6 +641,7 @@
 		27C34A3B20CEC5B1005EE649 /* CardMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardMetaData.swift; sourceTree = "<group>"; };
 		27C34A4220CEC635005EE649 /* CardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardInfo.swift; sourceTree = "<group>"; };
 		27C34A4520CECBA8005EE649 /* TermsAssetReferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAssetReferences.swift; sourceTree = "<group>"; };
+		27C76B0221A30D260067E7CF /* ProvisioningFailedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningFailedReason.swift; sourceTree = "<group>"; };
 		27CFE11D21236FF500AE116B /* JWTError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTError.swift; sourceTree = "<group>"; };
 		27CFE120212371D900AE116B /* JWS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWS.swift; sourceTree = "<group>"; };
 		27CFE1232123794000AE116B /* JWTUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTUtils.swift; sourceTree = "<group>"; };
@@ -1206,6 +1209,7 @@
 				CD038321306A4D9DE1077241 /* Commit.swift */,
 				1FE1479D201613CB005DEA29 /* CommitMetrics.swift */,
 				1FE147A220161F8B005DEA29 /* CommitStatistic.swift */,
+				2735864320E127CE005EDA9D /* Payload.swift */,
 				2782F83520F6B82D004774E8 /* Enums */,
 			);
 			path = Commit;
@@ -1228,6 +1232,7 @@
 			children = (
 				2782F83620F6B86E004774E8 /* TokenizationState.swift */,
 				2782F83A20F6B8B9004774E8 /* CreditCardInitiator.swift */,
+				27C76B0221A30D260067E7CF /* ProvisioningFailedReason.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1597,7 +1602,6 @@
 				CD038D1774A53D9340CFCFBE /* EncryptionKey.swift */,
 				37B85D591EF29FCB00B7616F /* Issuers.swift */,
 				2755F78F217E5EBE00C95AFD /* Link.swift */,
-				2735864320E127CE005EDA9D /* Payload.swift */,
 				2735864020E07021005EDA9D /* PlatformConfig.swift */,
 				CD038EC1AB0F5F167433FC52 /* ResourceLink.swift */,
 				CD0387ACA27383C2A0D33CBC /* ResultCollection.swift */,
@@ -2107,6 +2111,7 @@
 				27B8884D20A4C9DC0027969D /* ImageWithOptions.swift in Sources */,
 				3767B8161ED31BC2007443D2 /* RestClientUser.swift in Sources */,
 				3767B8191ED31D48007443D2 /* RestClientDevice.swift in Sources */,
+				27C76B0321A30D260067E7CF /* ProvisioningFailedReason.swift in Sources */,
 				3AF3A8F21DDB15AE0037E105 /* FitpaySDKLogger.swift in Sources */,
 				371CB2FD1F4449C50019A766 /* SyncFactory.swift in Sources */,
 				CD0386948E879E2106699B3C /* RestClient.swift in Sources */,
@@ -2426,6 +2431,7 @@
 				3767B8171ED31BC2007443D2 /* RestClientUser.swift in Sources */,
 				3767B81A1ED31D48007443D2 /* RestClientDevice.swift in Sources */,
 				276CD260209A65C500076648 /* FitpayConfig.swift in Sources */,
+				27C76B0421A30D260067E7CF /* ProvisioningFailedReason.swift in Sources */,
 				3A93A0A71DB8CA2C00A9FEB4 /* FitpayNotificationsManager.swift in Sources */,
 				3A93A0A91DB8CA2C00A9FEB4 /* RestSession.swift in Sources */,
 				91185B7F2061694400E5E1CE /* A2AVerificationRequest.swift in Sources */,

--- a/FitpaySDK/Extensions/Codable/KeyedDecodingContainerExtension.swift
+++ b/FitpaySDK/Extensions/Codable/KeyedDecodingContainerExtension.swift
@@ -18,9 +18,9 @@ extension KeyedDecodingContainer {
                 dictionary[key.stringValue] = intValue
             } else if let doubleValue = try? decode(Double.self, forKey: key) {
                 dictionary[key.stringValue] = doubleValue
-            } else if let nestedDictionary = try? decode(Dictionary<String, Any>.self, forKey: key) {
+            } else if let nestedDictionary = try? decode([String: Any].self, forKey: key) {
                 dictionary[key.stringValue] = nestedDictionary
-            } else if let nestedArray = try? decode(Array<Any>.self, forKey: key) {
+            } else if let nestedArray = try? decode([Any].self, forKey: key) {
                 dictionary[key.stringValue] = nestedArray
             }
         }

--- a/FitpaySDK/Rest/Models/Commit/Payload.swift
+++ b/FitpaySDK/Rest/Models/Commit/Payload.swift
@@ -4,7 +4,6 @@ open class Payload: NSObject, Serializable {
     
     open var creditCard: CreditCard?
     
-    var payloadDictionary: [String: Any]?
     var apduPackage: ApduPackage?
     
     private enum CodingKeys: String, CodingKey {
@@ -13,11 +12,8 @@ open class Payload: NSObject, Serializable {
     }
     
     public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         apduPackage = try? ApduPackage(from: decoder)
         creditCard = try? CreditCard(from: decoder)
-        
-        self.payloadDictionary = try? container.decode([String: Any].self)
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
@@ -31,7 +31,7 @@ import Foundation
     open var topOfWalletAPDUCommands: [APDUCommand]?
     open var tokenLastFour: String?
     
-    /// The reason a commit failed when returned in the payload of a non-apdu commit.
+    /// The reason a card provisioning failed. Returned in the payload of a non-apdu commit
     open var provisioningFailedReason: ProvisioningFailedReason?
     
     /// The credit card expiration month

--- a/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
@@ -22,14 +22,24 @@ import Foundation
     open var targetDeviceType: String?
     open var verificationMethods: [VerificationMethod]?
     open var externalTokenReference: String?
+    
+    /// Card information
+    ///
+    /// parsed from encryptedData or top level object if card is from Commit
     open var info: CardInfo?
-    open var topOfWalletAPDUCommands: [APDUCommand]? 
+    
+    open var topOfWalletAPDUCommands: [APDUCommand]?
     open var tokenLastFour: String?
     
-    /// The credit card expiration month - placed directly on card in creditCardCreated Events (otherwise in CardInfo)
+    /// The reason a commit failed when returned in the payload of a non-apdu commit.
+    open var provisioningFailedReason: ProvisioningFailedReason?
+    
+    /// The credit card expiration month
+    @available(*, deprecated, message: "as of v1.3.2 - parsed into CardInfo always")
     open var expMonth: Int?
     
-    /// The credit card expiration year in 4 digits - placed directly on card in creditCardCreated Events (otherwise in CardInfo)
+    /// The credit card expiration year in 4 digits
+    @available(*, deprecated, message: "as of v1.3.2 - parsed into CardInfo always")
     open var expYear: Int?
     
     /// returns true if acceptTermsResourceKey link is returned on the model and available to call
@@ -133,6 +143,7 @@ import Foundation
         case externalTokenReference
         case offlineSeActions
         case tokenLastFour
+        case provisioningFailedReason = "reason"
         case expMonth
         case expYear
     }
@@ -165,8 +176,13 @@ import Foundation
         topOfWalletAPDUCommands = offlineSeActions?.topOfWallet?.apduCommands
         
         tokenLastFour = try? container.decode(.tokenLastFour)
+        provisioningFailedReason = try? container.decode(.provisioningFailedReason)
+        
+        info = try? CardInfo(from: decoder)
+        
         expMonth = try? container.decode(.expMonth)
         expYear = try? container.decode(.expYear)
+        
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -191,6 +207,7 @@ import Foundation
         try? container.encode(verificationMethods, forKey: .verificationMethods)
         try? container.encode(externalTokenReference, forKey: .externalTokenReference)
         try? container.encode(tokenLastFour, forKey: .tokenLastFour)
+        try? container.encode(provisioningFailedReason, forKey: .provisioningFailedReason)
         try? container.encode(expMonth, forKey: .expMonth)
         try? container.encode(expYear, forKey: .expYear)
     }

--- a/FitpaySDK/Rest/Models/CreditCard/Enums/ProvisioningFailedReason.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/Enums/ProvisioningFailedReason.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Reason a provisioning attempt failed
+///
+/// - paymentNetworkRejection: the provision request was declined
+/// - noSecurityDomainAvailable: card network didn't have all of the information it needed to provision. might be because device didn't sync.
+/// - failedCredentialPersonalization: the perso wasn't processed in time or resulted in an error
+/// - sdCreateException: unexpected error, similar to a 400 http response
+/// - provisioningLimitReached: max number of credentials for the pan has been reached
+/// - userDeclinedTerms: user declined the issuer's terms and conditions document
+/// - failedRetrievingKeys: unexpected error, similar to a 400 http response
+/// - invalidDigitizationDecision: card network didn't provide a valid decision on the request
+/// - missingActivationMethods: provisioning request was approved with additional verification but no verification methods were provided
+/// - tokenStatusCompletionTimeout: card network didn't respond to the provision request
+/// - tokenStatusError: card network responded with an error during the provisioning process
+/// - unkown: unknown
+public enum ProvisioningFailedReason: String, Codable {
+    case paymentNetworkRejection            = "PAYMENT_NETWORK_REJECTION"
+    case noSecurityDomainAvailable          = "NO_SECURITY_DOMAIN_AVAILABLE"
+    case failedCredentialPersonalization    = "FAILED_CREDENTIAL_PERSONALIZATION"
+    case sdCreateException                  = "SD_CREATE_EXCEPTION"
+    case provisioningLimitReached           = "PROVISIONING_LIMIT_REACHED"
+    case userDeclinedTerms                  = "USER_DECLINED_TERMS"
+    case failedRetrievingKeys               = "FAILED_RETRIEVING_KEYS"
+    case invalidDigitizationDecision        = "INVALID_DIGITIZATION_DECISION"
+    case missingActivationMethods           = "MISSING_ACTIVATION_METHODS"
+    case tokenStatusCompletionTimeout       = "TOKEN_STATUS_COMPLETION_TIMEOUT"
+    case tokenStatusError                   = "TOKEN_STATUS_ERROR"
+    case unkown                             = "UNKNOWN"
+}

--- a/FitpaySDKTests/Rest/Models/CreditCard/CreditCardTests.swift
+++ b/FitpaySDKTests/Rest/Models/CreditCard/CreditCardTests.swift
@@ -32,7 +32,7 @@ class CreditCardTests: XCTestCase {
         expect(creditCard?.targetDeviceId).to(equal(mockModels.someId))
         expect(creditCard?.targetDeviceType).to(equal(mockModels.someType))
         expect(creditCard?.externalTokenReference).to(equal("someToken"))
-                
+        
         expect(creditCard?.links).toNot(beNil())
         expect(creditCard?.cardMetaData).toNot(beNil())
         expect(creditCard?.termsAssetReferences).toNot(beNil())
@@ -59,6 +59,48 @@ class CreditCardTests: XCTestCase {
         expect(json?["cardMetaData"]).toNot(beNil())
         expect(json?["termsAssetReferences"]).toNot(beNil())
         expect(json?["verificationMethods"]).toNot(beNil())
+    }
+    
+    func testCreditCardCommitParsing() {
+        let creditCard = mockModels.getCreditCardCommit()
+        
+        expect(creditCard?.creditCardId).to(equal(mockModels.someId))
+        expect(creditCard?.userId).to(equal(mockModels.someId))
+        expect(creditCard?.created).to(equal(mockModels.someDate))
+        expect(creditCard?.createdEpoch).to(equal(NSTimeIntervalTypeTransform().transform(mockModels.timeEpoch)))
+        expect(creditCard?.state).to(equal(TokenizationState.notEligible))
+        expect(creditCard?.cardType).to(equal(mockModels.someType))
+        expect(creditCard?.termsAssetId).to(equal(mockModels.someId))
+        expect(creditCard?.eligibilityExpiration).to(equal(mockModels.someDate))
+        expect(creditCard?.encryptedData).to(equal(mockModels.someEncryptionData))
+        expect(creditCard?.targetDeviceId).to(equal(mockModels.someId))
+        expect(creditCard?.targetDeviceType).to(equal(mockModels.someType))
+        expect(creditCard?.externalTokenReference).to(equal("someToken"))
+        expect(creditCard?.provisioningFailedReason).to(equal(ProvisioningFailedReason.provisioningLimitReached))
+        
+        expect(creditCard?.termsAssetReferences).toNot(beNil())
+        
+        expect(creditCard?.info?.name).to(equal("Bob"))
+        expect(creditCard?.info?.pan).to(equal("############1134"))
+        expect(creditCard?.info?.cvv).to(equal("###"))
+        expect(creditCard?.info?.expMonth).to(equal(11))
+        expect(creditCard?.info?.expYear).to(equal(2022))
+
+        let json = creditCard?.toJSON()
+        expect(json?["creditCardId"] as? String).to(equal(mockModels.someId))
+        expect(json?["createdTs"] as? String).to(equal(mockModels.someDate))
+        expect(json?["createdTsEpoch"] as? Int64).to(equal(mockModels.timeEpoch))
+        expect(json?["state"] as? String).to(equal("NOT_ELIGIBLE"))
+        expect(json?["cardType"] as? String).to(equal(mockModels.someType))
+        expect(json?["termsAssetId"] as? String).to(equal(mockModels.someId))
+        expect(json?["eligibilityExpiration"] as? String).to(equal(mockModels.someDate))
+        expect(json?["eligibilityExpirationEpoch"] as? Int64).to(equal(mockModels.timeEpoch))
+        expect(json?["encryptedData"] as? String).to(equal(mockModels.someEncryptionData))
+        expect(json?["targetDeviceId"] as? String).to(equal(mockModels.someId))
+        expect(json?["targetDeviceType"] as? String).to(equal(mockModels.someType))
+        expect(json?["externalTokenReference"] as? String).to(equal("someToken"))
+        
+        expect(json?["termsAssetReferences"]).toNot(beNil())
     }
     
     func testAvailable() {

--- a/FitpaySDKTests/TestSpecific/Mocks/MockModels.swift
+++ b/FitpaySDKTests/TestSpecific/Mocks/MockModels.swift
@@ -136,7 +136,15 @@ class MockModels {
         creditCard?.cardMetaData = getCreditCardMetadata()
         creditCard?.termsAssetReferences = [getTermsAssetReferences()!]
         creditCard?.verificationMethods = [getVerificationMethod()!]
-        creditCard?.info = getCreditCardInfo()
+        creditCard?.info = getCreditCardInfo() // normally grabbed from encrypted data
+        expect(creditCard).toNot(beNil())
+        return creditCard
+    }
+    
+    func getCreditCardCommit() -> CreditCard? {
+        let creditCard = try? CreditCard("{\"creditCardId\": \"\(someId)\",\"userId\": \"\(someId)\", \"createdTs\": \"\(someDate)\", \"createdTsEpoch\": \(timeEpoch), \"state\": \"NOT_ELIGIBLE\", \"cardType\": \"\(someType)\", \"termsAssetId\": \"\(someId)\", \"eligibilityExpiration\": \"\(someDate)\", \"eligibilityExpirationEpoch\": \(timeEpoch), \"encryptedData\":\"\(someEncryptionData)\", \"targetDeviceId\": \"\(someId)\", \"targetDeviceType\": \"\(someType)\", \"externalTokenReference\": \"someToken\", \"tokenLastFour\": \"4321\", \"reason\": \"PROVISIONING_LIMIT_REACHED\", \"expMonth\": 11, \"expYear\": 2022, \"name\": \"Bob\", \"pan\": \"############1134\", \"cvv\": \"###\"}")
+        
+        creditCard?.termsAssetReferences = [getTermsAssetReferences()!]
         expect(creditCard).toNot(beNil())
         return creditCard
     }


### PR DESCRIPTION
- Update CreditCard model to handle top level info
- deprecated expMonth and expYear