### PR TITLE
Transaction Model handles v1 and v2 parsing

### DIFF
--- a/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/CreditCard.swift
@@ -389,7 +389,7 @@ import Foundation
             return
         }
         
-        client.makeGetCall(url, limit: limit, offset: offset, completion: completion)
+        client.makeGetCall(url, limit: limit, offset: offset, overrideHeaders: ["Accept": "application/vnd.fitpay-v2+json"], completion: completion)
     }
     
     /**

--- a/FitpaySDK/Rest/Models/Transaction.swift
+++ b/FitpaySDK/Rest/Models/Transaction.swift
@@ -76,13 +76,11 @@ open class Transaction: NSObject, ClientModel, Serializable, SecretApplyable {
     func applySecret(_ secret: Data, expectedKeyId: String?) {
         guard let tmpTransaction: Transaction = JWE.decrypt(encryptedData, expectedKeyId: expectedKeyId, secret: secret) else { return }
 
-        transactionId = tmpTransaction.transactionId
+        // transactionId, transactionTime and transactionTimeEpoch are unencrypted
         transactionType = tmpTransaction.transactionType
         amount = tmpTransaction.amount
         currencyCode = tmpTransaction.currencyCode
         authorizationStatus = tmpTransaction.authorizationStatus
-        transactionTime = tmpTransaction.transactionTime
-        transactionTimeEpoch = tmpTransaction.transactionTimeEpoch
         merchantName = tmpTransaction.merchantName
         merchantCode = tmpTransaction.merchantCode
         merchantType = tmpTransaction.merchantType

--- a/FitpaySDK/Rest/RestClient.swift
+++ b/FitpaySDK/Rest/RestClient.swift
@@ -114,20 +114,22 @@ open class RestClient: NSObject {
         }
     }
 
-    func makeGetCall<T: Codable>(_ url: String, limit: Int, offset: Int, completion: @escaping ResultCollectionHandler<T>) {
+    func makeGetCall<T: Codable>(_ url: String, limit: Int, offset: Int, overrideHeaders: [String: String]? = nil, completion: @escaping ResultCollectionHandler<T>) {
         let parameters = ["limit": "\(limit)", "offset": "\(offset)"]
-        makeGetCall(url, parameters: parameters, completion: completion)
+        makeGetCall(url, parameters: parameters, overrideHeaders: overrideHeaders, completion: completion)
     }
     
-    func makeGetCall<T: Serializable>(_ url: String, parameters: [String: Any]?, completion: @escaping (T?, ErrorResponse?) -> Void) {
+    func makeGetCall<T: Serializable>(_ url: String, parameters: [String: Any]?, overrideHeaders: [String: String]? = nil, completion: @escaping (T?, ErrorResponse?) -> Void) {
         prepareAuthAndKeyHeaders { [weak self] (headers, error) in
             guard var headers = headers else {
                 DispatchQueue.main.async { completion(nil, error) }
                 return
             }
             
-            if url.contains("transactions") { // temporary until v2 upgrade
-                headers["Accept"] = "application/vnd.fitpay-v2+json"
+            if let overrideHeaders = overrideHeaders {
+                for key in overrideHeaders.keys {
+                    headers[key] = overrideHeaders[key]
+                }
             }
             
             self?.restRequest.makeRequest(url: url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: headers) { (resultValue, error) in

--- a/FitpaySDK/Rest/RestClient.swift
+++ b/FitpaySDK/Rest/RestClient.swift
@@ -121,9 +121,13 @@ open class RestClient: NSObject {
     
     func makeGetCall<T: Serializable>(_ url: String, parameters: [String: Any]?, completion: @escaping (T?, ErrorResponse?) -> Void) {
         prepareAuthAndKeyHeaders { [weak self] (headers, error) in
-            guard let headers = headers else {
+            guard var headers = headers else {
                 DispatchQueue.main.async { completion(nil, error) }
                 return
+            }
+            
+            if url.contains("transactions") { // temporary until v2 upgrade
+                headers["Accept"] = "application/vnd.fitpay-v2+json"
             }
             
             self?.restRequest.makeRequest(url: url, method: .get, parameters: parameters, encoding: URLEncoding.default, headers: headers) { (resultValue, error) in

--- a/FitpaySDKTests/Rest/Models/TransactionTests.swift
+++ b/FitpaySDKTests/Rest/Models/TransactionTests.swift
@@ -1,16 +1,47 @@
 import XCTest
+import Nimble
+
 @testable import FitpaySDK
 
 class TransactionTests: XCTestCase {
+    let mockModels = MockModels()
+
+    func testTransactionParsing() {
+        let transaction = mockModels.getTransaction()
+        
+        expect(transaction?.transactionId).to(equal("12345fsd"))
+        expect(transaction?.transactionType).to(equal("someType"))
+        expect(transaction?.amount).to(equal(3.22))
+        expect(transaction?.currencyCode).to(equal("code"))
+        expect(transaction?.authorizationStatus).to(equal("status"))
+        expect(transaction?.transactionTime).to(equal("time"))
+        expect(transaction?.transactionTimeEpoch).to(equal(1446587257))
+        expect(transaction?.merchantName).to(equal("someName"))
+        expect(transaction?.merchantCode).to(equal("code"))
+        expect(transaction?.merchantType).to(equal("someType"))
+
+        let json = transaction?.toJSON()
+        expect(json).toNot(beNil())
+        expect(json?["transactionId"] as? String).to(equal("12345fsd"))
+        expect(json?["transactionType"] as? String).to(equal("someType"))
+        expect(json?["amount"] as? String).to(equal("3.22"))
+        expect(json?["currencyCode"] as? String).to(equal("code"))
+        expect(json?["authorizationStatus"] as? String).to(equal("status"))
+        expect(json?["transactionTime"] as? String).to(equal("time"))
+        expect(json?["transactionTimeEpoch"] as? TimeInterval).to(equal(1446587257000))
+        expect(json?["merchantName"] as? String).to(equal("someName"))
+        expect(json?["merchantCode"] as? String).to(equal("code"))
+        expect(json?["merchantType"] as? String).to(equal("someType"))
+
+    }
     
     func testParsingDecimalValue() {
         let transaction = try? Transaction("{\"amount\": 0.691}")
+        expect(transaction).toNot(beNil())
+        expect(transaction!.amount?.description ?? "").to(equal("0.691"))
         
-        XCTAssertNotNil(transaction)
-        XCTAssertEqual(transaction!.amount?.description ?? "", "0.691")
-
-        let json = transaction?.toJSON()
-        XCTAssertNotNil(json)
-        XCTAssertEqual(json?["amount"] as? String, "0.691")
+        let transaction2 = try? Transaction("{\"amount\": \"0.691\"}")
+        expect(transaction2).toNot(beNil())
+        expect(transaction2!.amount?.description ?? "").to(equal("0.691"))
     }
 }

--- a/FitpaySDKTests/TestSpecific/Mocks/MockModels.swift
+++ b/FitpaySDKTests/TestSpecific/Mocks/MockModels.swift
@@ -20,7 +20,7 @@ class MockModels {
     }
     
     func getTransaction() -> Transaction? {
-        let transaction = try? Transaction("{\"_links\":{\"self\":{\"href\":\"https://api.fit-pay.com/users/9469bfe0-3fa1-4465-9abf-f78cacc740b2/devices/677af018-01b1-47d9-9b08-0c18d89aa2e3/commits/57717bdb6d213e810137ee21adb7e883fe0904e9\"}},\"transactionId\":\"\(someId)\",\"transactionType\":\"\(someType)\",\"amount\":3.22,\"currencyCode\":\"code\",\"authorizationStatus\":\"status\",\"authorizationStatus\":\"status\",\"transactionTime\":\"time\",\"transactionTimeEpoch\":\(timeEpoch),\"merchantName\":\"\(someName)\",\"merchantCode\":\"code\",\"merchantType\":\"\(someType)\"}")
+        let transaction = try? Transaction("{\"_links\":{\"self\":{\"href\":\"https://api.fit-pay.com/users/9469bfe0-3fa1-4465-9abf-f78cacc740b2/devices/677af018-01b1-47d9-9b08-0c18d89aa2e3/commits/57717bdb6d213e810137ee21adb7e883fe0904e9\"}},\"transactionId\":\"\(someId)\",\"transactionType\":\"\(someType)\",\"amount\":3.22,\"currencyCode\":\"code\",\"authorizationStatus\":\"status\",\"transactionTime\":\"time\",\"transactionTimeEpoch\":\(timeEpoch),\"merchantName\":\"\(someName)\",\"merchantCode\":\"code\",\"merchantType\":\"\(someType)\"}")
         expect(transaction).toNot(beNil())
         return transaction
     }


### PR DESCRIPTION
- pass in v2 header for transaction calls only
- add encryptedData and secretApplyable to Transaction
- improve tests