### PR TITLE
Sync fix

### DIFF
--- a/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
+++ b/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
@@ -57,10 +57,10 @@ open class SyncRequest {
     /// - Parameters:
     ///   - notification: Notification Detail created from a FitPay notification
     ///   - initiator: where the sync is coming from, defaulting to notification
-    public init(notification: NotificationDetail? = nil, initiator: SyncInitiator = .notification) {
+    public init(notification: NotificationDetail? = nil, initiator: SyncInitiator = .notification, user: User? = nil) {
         self.requestTime = Date()
         self.syncId = notification?.syncId
-        self.user = nil
+        self.user = user
         let deviceInfo = Device()
         deviceInfo.deviceIdentifier = notification?.deviceId
         self.deviceInfo = deviceInfo

--- a/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
+++ b/FitpaySDK/PaymentDevice/SyncQueue/SyncRequest.swift
@@ -57,6 +57,7 @@ open class SyncRequest {
     /// - Parameters:
     ///   - notification: Notification Detail created from a FitPay notification
     ///   - initiator: where the sync is coming from, defaulting to notification
+    ///   - user: The user associated with the notification, defaulting to nil
     public init(notification: NotificationDetail? = nil, initiator: SyncInitiator = .notification, user: User? = nil) {
         self.requestTime = Date()
         self.syncId = notification?.syncId


### PR DESCRIPTION
FCM notifications include the userId but no other user information, so when we tried to handle events coming from Firebase we weren't able to set the user on the syncRequest object, which caused the SyncRequestQueue to skip over the notification.

Now we get the user from RestClient and use it to initialize the syncRequest, which fixes the problem.