### PR TITLE
CA-75738

### DIFF
--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -286,6 +286,13 @@ class EventSource: NSObject {
         return true
     }
     
+    private func openCallbackAllocated() -> Bool{
+        if onOpenCallback == nil {
+            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error onOpenCallback nil")
+            return false
+        }
+        return true
+    }
 }
 
 extension EventSource: URLSessionDataDelegate {
@@ -316,13 +323,11 @@ extension EventSource: URLSessionDataDelegate {
         }
         
         //Set ready state to open when the open when callback is known not to be nil
-        if self.onOpenCallback != nil {
+        if openCallbackAllocated() {
             self.readyState = .open
             DispatchQueue.main.async {
                 self.onOpenCallback!()
             }
-        } else {
-            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error onOpenCallback nil")
         }
     }
     

--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -276,14 +276,14 @@ class EventSource: NSObject {
         return false
     }
     
-    private func receivedValidResponse(_ httpResponse: HTTPURLResponse?) -> Bool {
+    private func receivedInvalidResponse(_ httpResponse: HTTPURLResponse?) -> Bool {
         guard let response = httpResponse else { return false }
         
         if response.statusCode == 200 {
-            return true
+            return false
         }
         FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error status code: \(response.statusCode)")
-        return false
+        return true
     }
     
 }
@@ -311,7 +311,7 @@ extension EventSource: URLSessionDataDelegate {
             return
         }
         
-        if self.receivedValidResponse(dataTask.response as? HTTPURLResponse) {
+        if self.receivedInvalidResponse(dataTask.response as? HTTPURLResponse) {
             return
         }
         

--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -312,6 +312,7 @@ extension EventSource: URLSessionDataDelegate {
             return
         }
         
+        //Set ready state to open when the open when callback is known not to be nil
         if self.onOpenCallback != nil {
             self.readyState = .open
             DispatchQueue.main.async {

--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -297,11 +297,22 @@ extension EventSource: URLSessionDataDelegate {
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         completionHandler(URLSession.ResponseDisposition.allow)
         
+        guard let httpResponse = response as? HTTPURLResponse else {
+            FitpaySDKLogger.sharedInstance.error("EVENT_STREAM_ERROR cannot cast urlResponse")
+            return
+        }
+        
+        //Any other codes that should allow sucess?
+        guard httpResponse.statusCode == 200 else {
+            FitpaySDKLogger.sharedInstance.error("EVENT_STREAM_ERROR status code: \(httpResponse.statusCode)")
+            return
+        }
+ 
         if self.receivedMessageToClose(dataTask.response as? HTTPURLResponse) {
             return
         }
         
-        self.readyState = EventSourceState.open
+        self.readyState = .open
         if self.onOpenCallback != nil {
             DispatchQueue.main.async {
                 self.onOpenCallback!()

--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -286,13 +286,6 @@ class EventSource: NSObject {
         return true
     }
     
-    private func openCallbackAllocated() -> Bool{
-        if onOpenCallback == nil {
-            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error onOpenCallback nil")
-            return false
-        }
-        return true
-    }
 }
 
 extension EventSource: URLSessionDataDelegate {
@@ -323,11 +316,13 @@ extension EventSource: URLSessionDataDelegate {
         }
         
         //Set ready state to open when the open when callback is known not to be nil
-        if openCallbackAllocated() {
+        if self.onOpenCallback != nil {
             self.readyState = .open
             DispatchQueue.main.async {
                 self.onOpenCallback!()
             }
+        } else {
+            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error onOpenCallback nil")
         }
     }
     

--- a/FitpaySDK/Notifications/EventStream/EventSource.swift
+++ b/FitpaySDK/Notifications/EventStream/EventSource.swift
@@ -298,25 +298,27 @@ extension EventSource: URLSessionDataDelegate {
         completionHandler(URLSession.ResponseDisposition.allow)
         
         guard let httpResponse = response as? HTTPURLResponse else {
-            FitpaySDKLogger.sharedInstance.error("EVENT_STREAM_ERROR cannot cast urlResponse")
+            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error cannot cast urlResponse")
             return
         }
         
-        //Any other codes that should allow sucess?
         guard httpResponse.statusCode == 200 else {
-            FitpaySDKLogger.sharedInstance.error("EVENT_STREAM_ERROR status code: \(httpResponse.statusCode)")
+            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error status code: \(httpResponse.statusCode)")
             return
         }
  
+        //204
         if self.receivedMessageToClose(dataTask.response as? HTTPURLResponse) {
             return
         }
         
-        self.readyState = .open
         if self.onOpenCallback != nil {
+            self.readyState = .open
             DispatchQueue.main.async {
                 self.onOpenCallback!()
             }
+        } else {
+            FitpaySDKLogger.sharedInstance.error("USER_EVENT_STREAM error onOpenCallback nil")
         }
     }
     

--- a/FitpaySDK/Notifications/EventStream/UserEventStream.swift
+++ b/FitpaySDK/Notifications/EventStream/UserEventStream.swift
@@ -12,11 +12,11 @@ class UserEventStream {
         client.prepareAuthAndKeyHeaders { (headers, error) in
             self.eventSource = EventSource(url: eventStreamLink, headers: [:])
             
-            self.eventSource!.onOpen {
+            self.eventSource?.onOpen {
                 log.debug("USER_EVENT_STREAM: connected to event stream for user \(user.id ?? "no user")")
             }
             
-            self.eventSource!.onError { (error) in
+            self.eventSource?.onError { (error) in
                 guard let error = error else { return }
                 if error.code == -999 { //cancelled
                     log.debug("USER_EVENT_STREAM: connection closed for user \(user.id ?? "no user")")
@@ -25,7 +25,7 @@ class UserEventStream {
                 }
             }
             
-            self.eventSource!.onMessage { (_, _, data) in
+            self.eventSource?.onMessage { (_, _, data) in
                 guard let jwtBodyString = JWE.decryptSigned(data, expectedKeyId: client.key?.keyId, secret: client.secret) else { return }
                 guard let streamEvent = try? jsonDecoder.decode(StreamEvent.self, from: jwtBodyString.data(using: String.Encoding.utf8)!) else { return }
                 

--- a/FitpaySDK/Notifications/NotificationDetail.swift
+++ b/FitpaySDK/Notifications/NotificationDetail.swift
@@ -15,7 +15,7 @@ open class NotificationDetail: Serializable, ClientModel {
     open var clientId: String?
     open var creditCardId: String?
     
-    weak var client: RestClient?
+    weak public var client: RestClient?
     
     var links: [String: Link]?
 

--- a/FitpaySDK/PaymentDevice/Operations/FetchCommitsOperation.swift
+++ b/FitpaySDK/PaymentDevice/Operations/FetchCommitsOperation.swift
@@ -69,6 +69,7 @@ class FetchCommitsOperation: FetchCommitsOperationProtocol {
                 loadCommits(afterCommit: commit)
                 return
             case .completed:
+                self?.publisher.onCompleted()
                 break
             }
         }.disposed(by: disposeBag)

--- a/FitpaySDK/PaymentDevice/Operations/FetchCommitsOperation.swift
+++ b/FitpaySDK/PaymentDevice/Operations/FetchCommitsOperation.swift
@@ -69,7 +69,6 @@ class FetchCommitsOperation: FetchCommitsOperationProtocol {
                 loadCommits(afterCommit: commit)
                 return
             case .completed:
-                self?.publisher.onCompleted()
                 break
             }
         }.disposed(by: disposeBag)

--- a/FitpaySDK/PaymentDevice/Operations/SyncOperation.swift
+++ b/FitpaySDK/PaymentDevice/Operations/SyncOperation.swift
@@ -100,6 +100,7 @@ class SyncOperation {
     }
     
     private func sync() {
+        self.syncRequest?.notification?.sendAckSync()
         self.fetchCommitsOperation.startWith(limit: 20, andOffset: 0).subscribe { [weak self] (e) in
             switch e {
             case .error(let error):
@@ -119,7 +120,6 @@ class SyncOperation {
                     
                     log.verbose("SYNC_DATA: Commit applier returned without errors.")
                     
-                    self?.sendCommitsMetric()
                     self?.state.value = .completed(nil)
                 }
                 

--- a/FitpaySDK/Rest/Models/User/User.swift
+++ b/FitpaySDK/Rest/Models/User/User.swift
@@ -37,7 +37,7 @@ open class User: NSObject, ClientModel, Serializable, SecretApplyable {
     var encryptedData: String?
     var info: UserInfo?
     
-    weak var client: RestClient?
+    weak public var client: RestClient?
     
     private static let creditCardsResourceKey = "creditCards"
     private static let devicesResourceKey = "devices"

--- a/FitpaySDK/Rest/RestRequest.swift
+++ b/FitpaySDK/Rest/RestRequest.swift
@@ -13,7 +13,6 @@ class RestRequest: RestRequestable {
     lazy var manager: SessionManager = {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
-        configuration.urlCache = nil // fix for caching issue.
         
         return SessionManager(configuration: configuration)
     }()

--- a/FitpaySDK/Rest/RestRequest.swift
+++ b/FitpaySDK/Rest/RestRequest.swift
@@ -13,6 +13,7 @@ class RestRequest: RestRequestable {
     lazy var manager: SessionManager = {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+        configuration.urlCache = nil // "Fix" for caching issue.
         
         return SessionManager(configuration: configuration)
     }()


### PR DESCRIPTION
The following changes will allow Ack’s to be sent:

Calling sendAckSync call to beginning of sync process
Exposing the RestClient attribute of User to consuming apps

The following changes will improve the reliability of the event stream:

Setting the open state once a connection has been confirmed to be possible
Ensuring a 200 before setting the open state

Misc changes:
Logging
Removed force unwrapping in UserEventStream.swift
Removed unnecessary sendCommitsMetric in SyncOperation.swift