### PR TITLE
Set restClient attribute in device, event stream, and issuer's to public.

### DIFF
--- a/FitpaySDK/Notifications/EventStream/UserEventStreamManager.swift
+++ b/FitpaySDK/Notifications/EventStream/UserEventStreamManager.swift
@@ -3,7 +3,7 @@ import Foundation
 public class UserEventStreamManager {
     public static let sharedInstance = UserEventStreamManager()
     
-    private var client: RestClient?
+    public var client: RestClient?
     private var userEventStreams: [String: UserEventStream] = [:]
     
     public typealias userEventStreamHandler = (_ event: StreamEvent) -> Void

--- a/FitpaySDK/Rest/Models/CreditCard/Issuers.swift
+++ b/FitpaySDK/Rest/Models/CreditCard/Issuers.swift
@@ -4,7 +4,7 @@ open class Issuers: Serializable, ClientModel {
     
     public var countries: [String: Country]?
     
-    weak var client: RestClient?
+    public weak var client: RestClient?
 
     private enum CodingKeys: String, CodingKey {
         case countries

--- a/FitpaySDK/Rest/Models/Device/Device.swift
+++ b/FitpaySDK/Rest/Models/Device/Device.swift
@@ -119,7 +119,7 @@ import Foundation
     }
     
     var links: [String: Link]?
-    weak var client: RestClient?
+    public weak var client: RestClient?
 
     typealias NotificationTokenUpdateCompletion = (_ changed: Bool, _ error: ErrorResponse?) -> Void
     


### PR DESCRIPTION
Need these exposed when creating sync requests to successfully handle multiple devices being synced in a row.